### PR TITLE
Allow appending the helper to the container instead of the document body

### DIFF
--- a/src/ContainerMixin.js
+++ b/src/ContainerMixin.js
@@ -20,6 +20,7 @@ export const ContainerMixin = {
         move: this.handleMove,
         end: this.handleEnd,
       },
+      appendHelperToContainerInternal: this.appendHelperToContainer,
     };
   },
 
@@ -35,6 +36,7 @@ export const ContainerMixin = {
     lockToContainerEdges:       { type: Boolean, default: false },
     lockOffset:                 { type: [String, Number, Array], default: '50%' },
     transitionDuration:         { type: Number,  default: 300 },
+    appendHelperToContainer:    { type: Boolean, default: false },
     lockAxis: String,
     helperClass: String,
     contentWindow: Object,
@@ -242,7 +244,11 @@ export const ContainerMixin = {
           }
         });
 
-        this.helper = this.document.body.appendChild(clonedNode);
+        if (this.appendHelperToContainerInternal === true) {
+          this.helper = this.container.appendChild(clonedNode);
+        } else {
+          this.helper = this.document.body.appendChild(clonedNode);
+        }
 
         this.helper.style.position = 'fixed';
         this.helper.style.top = `${this.boundingClientRect.top - margin.top}px`;


### PR DESCRIPTION
It is done via a new prop `appendHelperToContainer` that defaults to false for backwards compatibility.