### PR TITLE
On end fix

### DIFF
--- a/src/ContainerMixin.js
+++ b/src/ContainerMixin.js
@@ -261,6 +261,7 @@ export const ContainerMixin = {
           node.style.opacity = 0;
         }
 
+        this.translate = {};
         this.minTranslate = {};
         this.maxTranslate = {};
         if (this._axis.x) {

--- a/src/ContainerMixin.js
+++ b/src/ContainerMixin.js
@@ -432,13 +432,17 @@ export const ContainerMixin = {
       return new Promise(resolve => {
         // Register an event handler to clean up styles when the transition
         // finishes.
-        this.helper.addEventListener('transitionend', event => {
-          if (event.propertyName === 'transform') {
+        const cleanup = event => {
+          if (!event || event.propertyName === 'transform') {
+            clearTimeout(cleanupTimer);
             this.helper.style[`${vendorPrefix}Transform`] = '';
             this.helper.style[`${vendorPrefix}TransitionDuration`] = '';
             resolve();
           }
-        }, false);
+        };
+        // Force cleanup in case 'transitionend' never fires
+        const cleanupTimer = setTimeout(cleanup, duration + 10);
+        this.helper.addEventListener('transitionend', cleanup, false);
       });
     },
 


### PR DESCRIPTION
I think I figured it out. My issue is related to single/double clicking a list item without moving its position. When you do this, sometimes the move event doesn't fire, causing **this.translate** to be undefined.

I also noticed a related issue. The **transitionend** event is not always fired leading to an incomplete promise. Maybe this is some kind of optimization in Chrome? Anyway I think this needs further testing and review.