### PR TITLE
Add event listeners in passive mode.

### DIFF
--- a/src/ContainerMixin.js
+++ b/src/ContainerMixin.js
@@ -74,7 +74,7 @@ export const ContainerMixin = {
     for (const key in this.events) {
       if (this.events.hasOwnProperty(key)) {
         events[key].forEach(eventName =>
-          this.container.addEventListener(eventName, this.events[key], false)
+          this.container.addEventListener(eventName, this.events[key], {passive: true})
         );
       }
     }


### PR DESCRIPTION
This gets rid of the following warnings: [Violation] Added non-passive event listener to a scroll-blocking 'touchmove' event. Consider marking event handler as 'passive' to make the page more responsive. See https://www.chromestatus.com/feature/5745543795965952