### PR TITLE
Fix: Dragging broken on Android when distance property is set

### DIFF
--- a/src/ContainerMixin.js
+++ b/src/ContainerMixin.js
@@ -100,10 +100,7 @@ export const ContainerMixin = {
       }
 
       this._touched = true;
-      this._pos = {
-        x: e.pageX,
-        y: e.pageY,
-      };
+      this._pos = this.getOffset(e);
 
       const node = closest(e.target, el => el.sortableInfo != null);
 
@@ -153,9 +150,10 @@ export const ContainerMixin = {
       const {distance, pressThreshold} = this.$props;
 
       if (!this.sorting && this._touched) {
+        const offset = this.getOffset(e);
         this._delta = {
-          x: this._pos.x - e.pageX,
-          y: this._pos.y - e.pageY,
+          x: this._pos.x - offset.x,
+          y: this._pos.y - offset.y,
         };
         const delta = Math.abs(this._delta.x) + Math.abs(this._delta.y);
 
@@ -462,9 +460,10 @@ export const ContainerMixin = {
     },
 
     getOffset(e) {
+      const { pageX, pageY } = e.touches ? e.touches[0] : e;
       return {
-        x: e.touches ? e.touches[0].pageX : e.pageX,
-        y: e.touches ? e.touches[0].pageY : e.pageY,
+        x: pageX,
+        y: pageY,
       };
     },
 


### PR DESCRIPTION
Fixes: https://github.com/Jexordexan/vue-slicksort/issues/125

When the `distance` property is set, drag behavior breaks on Android devices. Looks like this is because the position property isn't properly being set to the `e.touches[0]` value when calculating the delta on touch events. 

Minimal Reproduction:
https://jsfiddle.net/linnea/aoq792jp/14/