### PR TITLE
fix: get collection from node.sortableInfo

### DIFF
--- a/src/ContainerMixin.js
+++ b/src/ContainerMixin.js
@@ -196,8 +196,8 @@ export const ContainerMixin = {
           useWindowAsScrollContainer,
           appendTo,
         } = this.$props;
-        const {node, collection} = active;
-        const {index} = node.sortableInfo;
+        const {node} = active;
+        const {index, collection} = node.sortableInfo;
         const margin = getElementMargin(node);
 
         const containerBoundingRect = this.container.getBoundingClientRect();


### PR DESCRIPTION
hello, I found a bug, the `collection` property was exists in `node.sortableInfo`, not in the `ref` object.