### PR TITLE
Fix bug with autoscroll

### DIFF
--- a/src/ContainerMixin.js
+++ b/src/ContainerMixin.js
@@ -68,7 +68,7 @@ export const ContainerMixin = {
     this.document = this.container.ownerDocument || document;
     this._window = this.contentWindow || window;
     this.scrollContainer = this.useWindowAsScrollContainer
-      ? this.document.body
+      ? this.document.documentElement
       : this.container;
 
     for (const key in this.events) {


### PR DESCRIPTION
Fix bug when autoscroll does not work correctly with useWindowAsScrollContainer. document.body has no scrollTop value in several cases, but document.documentElement works fine always.