### PR TITLE
fix: set sortableGhost to null when sort ended

### DIFF
--- a/src/ContainerMixin.ts
+++ b/src/ContainerMixin.ts
@@ -655,6 +655,7 @@ export const ContainerMixin = defineComponent({
         if (this.hideSortableGhost && this.sortableGhost) {
           this.sortableGhost.style.visibility = '';
           this.sortableGhost.style.opacity = '';
+          this.sortableGhost = null;
         }
 
         resetTransform(nodes);


### PR DESCRIPTION
Click on an item in a list with `group` + `press-delay` will trigger the drag canceled which will clean up the sortableGhost by removing it. But the sortableGhost is also used for setting it to invisible when sorted in place. So in the drag canceled handler will remove the item that we just sorted.

Fixed #161