### PR TITLE
fix: Module '"vue-slicksort"' has no exported member 'DragHandle'.ts(2305)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,7 @@ declare module 'vue-slicksort' {
 
   export const SlickList: Component;
   export const SlickItem: Component;
+  export const DragHandle: Component;
 
   export const HandleDirective: DirectiveOptions;
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/17776279/215108126-ce99a4af-4abe-4964-9641-3f02f692693c.png)

* Add missing "DragHandle" in index.d.ts